### PR TITLE
Update Window.tsx

### DIFF
--- a/src/components/Window.tsx
+++ b/src/components/Window.tsx
@@ -10,7 +10,7 @@ import { Size, Grids, Bounds } from "./index.d";
 
 export interface Props {
   id: string;
-  children: JSX.Element;
+  children: React.ReactNode;
   grids: Grids;
   title?: JSX.Element;
   bounds?: Bounds;


### PR DESCRIPTION
JSX.Element as the type for children causes issues. The natural type for children is React.ReactNode however I think the proper way to fix this is to remove children from the props interface and type the component but I'm not sure what other linting errors this would cause for you.
```const Window: React.FC<Props> = (props: Props) => {```

for now the workaround is to make the children like so:

```

<WindowsProvider>
      <Windows taskbar={true} step={5}>
        {[
          <Window
            id="window1"
            grids={{
              mobile: { x: 0, y: 0, w: 12, h: 1 },
              tablet: { x: 0, y: 0, w: 6, h: 3 },
              desktop: { x: 0, y: 0, w: 4, h: 4 },
            }}
            title={<div>Window 1</div>}
          >
            <div style={{ padding: '1rem' }}>Draggable, resizable, minimizable and maximizable.</div>
          </Window>,
        ]}
      </Windows>
    </WindowsProvider>

```